### PR TITLE
Change tutorial modes on comment editor show/hide (fixes #162)

### DIFF
--- a/src/client/scripts/view.js
+++ b/src/client/scripts/view.js
@@ -147,11 +147,9 @@ define([
           }
           view.hideComments();
           view.showCommentEditor(line_start,line_end);
-          tutorial.commentInputMode();
         } else {
           view.hideCommentEditor();
           view.showComments();
-          tutorial.commentDisplayMode();
         }
       }
     });
@@ -171,6 +169,7 @@ define([
 
   view.hideCommentEditor = function() {
     $('#comment-new').hide();
+    tutorial.commentDisplayMode();
   };
 
   view.showCommentEditor = function(start,end) {
@@ -183,6 +182,7 @@ define([
     var pos = editor.getLinePosition(start);
     $('#comment-new').css('top',pos);
     $('#comment-new').slideDown();
+    tutorial.commentInputMode();
   };
 
   view.displayError = function(err_html) {


### PR DESCRIPTION
This is not the elegant solution. It seems the 'mode' should be a property of the view, and other modules, such as tutorial, should be able to read the current mode and listen for 'mode-change' events.
